### PR TITLE
Refactor Merge Step

### DIFF
--- a/src/analytics/Builder.ts
+++ b/src/analytics/Builder.ts
@@ -1,18 +1,21 @@
 import { Curriculum, Vertex } from '../types/analytics'
-import { CalculateCreditHours, DeepCopy, FindCoreqs, GetPreReqs, UpdateRelativeSemesterLocks } from './utils'
+import { CalculateCreditHours, DeepCopy, FindCoreqs, GetPreReqs, UpdateRelativeSemesterLocks, SortVertices } from './utils'
 
-export async function Builder(curriculum: Curriculum): Promise<Vertex[][]> {
-    const semesters: Vertex[][] = new Array(curriculum.semesters.length).fill(0).map(_ => new Array)
+export async function Builder(curriculum: { [code: string]: Vertex }): Promise<Vertex[][]> {
+    const allCourses = Object.values(curriculum)
+    const semesters: Vertex[][] = new Array(Math.max(...allCourses.map(c => c.semester))).fill(0).map(_ => new Array)
     const coursesWithLocks: Vertex[] = []
     // Copy the courses from the passed in curriculum, splitting them into different arrays depending if they have semester locks or not
     // then sort the non-semester locked courses based on their course number
-    const courses = DeepCopy<Vertex[]>(curriculum.semesters.flat()).filter(course => {
+    const courseList = DeepCopy<Vertex[]>(Object.values(curriculum)).filter(course => {
         if (course.semesterLock?.length > 0) {
             coursesWithLocks.push(DeepCopy<Vertex>(course))
             return false
         }
         return true
-    }).sort((c1, c2) => +/(\d+)/.exec(c1.courseCode)[0] - +/(\d+)/.exec(c2.courseCode)[0])
+    })
+    const courses = SortVertices(courseList)
+    console.log(courses.map(x => x.courseCode).join(', '))
     // Add locked courses first, including any coreqs attached to them
     for (const lockedCourse of coursesWithLocks) {
         if (semesters.flat().find(v => v.courseCode === lockedCourse.courseCode) === undefined) {
@@ -32,7 +35,7 @@ export async function Builder(curriculum: Curriculum): Promise<Vertex[][]> {
     while (courses.length > 0) {
         const course = courses[0]
         const creditHours = CalculateCreditHours(semesters)
-        const prereqs = await GetPreReqs(curriculum, course)
+        const prereqs = await GetPreReqs(allCourses, course)
         const minSemesterIndex = prereqs.length ? Math.max(...prereqs.map(c => c.semester)) : 0
         // Find any coreqs relating to the current course
         const coreqs = await FindCoreqs(courses, course)
@@ -40,6 +43,7 @@ export async function Builder(curriculum: Curriculum): Promise<Vertex[][]> {
         const totalCreditSumForCurrentGroup = currentCourseGroup.reduce((total, currCourse) => total + currCourse.credits, 0)
         // Find the first semester that can accomodate the current course and its coreqs
         const semesterIndex = semesters.findIndex((_, sIndex) => sIndex >= minSemesterIndex && (creditHours[sIndex] + totalCreditSumForCurrentGroup) <= 18)
+        console.log(`MSI: ${minSemesterIndex} | # of prereqs found: ${prereqs.length} | TC For Curr Group (${course.courseCode}): ${totalCreditSumForCurrentGroup} | SI: ${semesterIndex}`)
         if (semesterIndex === -1) {
             // Couldn't accommodate the current group, add an additional semester
             console.log(`Could not accommodate ${course.courseCode} in the current layout, adding an additional semester`)

--- a/src/analytics/EGA.ts
+++ b/src/analytics/EGA.ts
@@ -72,7 +72,7 @@ async function Mutate(curriculum: Curriculum, alreadyAttemptedMoves: string[]): 
         alreadyAttemptedMoves.push(courseToMove.courseCode)
         if (courseToMove.semesterLock?.length) continue
         // console.log(`[Mutation]: Trying to move ${courseToMove.courseCode}`)
-        const minSemesterIndex = (await GetPreReqs(tempCurriculum, courseToMove)).filter((v, i, a) => a.findIndex(v2 => v2.semester === v.semester) === i).length
+        const minSemesterIndex = (await GetPreReqs(tempCurriculum.semesters.flat(), courseToMove)).filter((v, i, a) => a.findIndex(v2 => v2.semester === v.semester) === i).length
         if (minSemesterIndex + 1 < courseToMove.semester) { // We can try to move the course to earlier in the plan
             const potentialSemesterIndices = new Array(courseToMove.semester - (minSemesterIndex + 1)).fill(0).map((_, i) => minSemesterIndex + i)
             // console.log(`Potenial semester indicies: ${potentialSemesters.join(', ')}`)

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -25,15 +25,20 @@ export async function ParseAnalytics(programStacks: string[]): Promise<Analytics
         await writeFile('./buffer.json', JSON.stringify(curricula[0]), { encoding: 'utf-8' })    
         return curricula[0]
     }
+    const plan: Analytics.Curriculum = {
+        semesters: [],
+        structuralComplexity: 0,
+        totalCredits: 0
+    }
     console.log('Multiple curricula found')
     const mergedCurricula = await MergeCurricula(curricula)
     await CalculateMetrics(mergedCurricula)
-    for (const course of mergedCurricula.semesters.flat()) { // Generate colors based on the unique course codes
+    for (const course of Object.values(mergedCurricula)) { // Generate colors based on the unique course codes
         course.color = GenerateHexCodeFromCourseCode(course.courseCode)
     }
     await writeFile('./merged-buffer.json', JSON.stringify(mergedCurricula), { encoding: 'utf-8' })
-    mergedCurricula.semesters = await Builder(mergedCurricula)
-    const optimizedDegreePlan = await OptimizeCurriculum(mergedCurricula)
+    plan.semesters = await Builder(mergedCurricula)
+    const optimizedDegreePlan = await OptimizeCurriculum(plan)
     await writeFile('./buffer.json', JSON.stringify(optimizedDegreePlan), { encoding: 'utf-8' })
     const finalDegreePlan: Analytics.Curriculum = await EGA([optimizedDegreePlan])
     await writeFile('./EGA-buffer.json', JSON.stringify(finalDegreePlan), { encoding: 'utf-8' })

--- a/src/analytics/merge.ts
+++ b/src/analytics/merge.ts
@@ -13,7 +13,7 @@ export async function MergeCurricula(curricula: Curriculum[]): Promise<Curriculu
     console.log('Starting merge step')
     const mergedCurriculum: Curriculum = {
         semesters: new Array(Math.max(...curricula.flatMap(c => c.semesters.length))).fill(null).map(x => []),
-        totalCredits: curricula.reduce((a, b) => a + b.totalCredits, 0) // FIXME: this is just incorrect, once we want to actually use this we'll need to fix it
+        totalCredits: 0
     }
     console.log(`Generated ${mergedCurriculum.semesters.length} blank semesters`)
     // Create object reference/pointer to the semesters as a shorthand
@@ -195,6 +195,7 @@ export async function MergeCurricula(curricula: Curriculum[]): Promise<Curriculu
 
     console.log('Merge step complete')
     mergedCurriculum.semesters = mergedCurriculum.semesters.map(semester => semester.sort((a, b) => createHash('md5').update(a.courseCode).digest('hex').split('').reduce((a, c) => a + c.charCodeAt(0), 0) - createHash('md5').update(b.courseCode).digest('hex').split('').reduce((a, c) => a + c.charCodeAt(0), 0)))
+    mergedCurriculum.totalCredits = mergedCurriculum.semesters.reduce((acc, curr) => acc + curr.reduce((acc2, curr2) => acc2 + curr2.credits, 0), 0)
     return mergedCurriculum
 }
 

--- a/src/analytics/merge.ts
+++ b/src/analytics/merge.ts
@@ -1,220 +1,32 @@
-import { ShiftBranch, calculateCoursePath, DeepCopy, UpdateMovedCourses } from './utils'
-import { Curriculum, Vertex } from '../types/analytics'
-import { readFile, writeFile } from 'fs/promises'
-import { createHash } from 'node:crypto'
+import { Curriculum, Vertex } from "../types/analytics"
+import { DeepCopy } from "./utils"
 
 /**
-Identify common courses
-For each common course, merge their edges/post-reqs
-calculate paths for the course in each curriculum is appears in
-use the semester spacing in each path to determine where the duplicate course should be placed for merging
-*/
-export async function MergeCurricula(curricula: Curriculum[]): Promise<Curriculum> {
-    console.log('Starting merge step')
-    const mergedCurriculum: Curriculum = {
-        semesters: new Array(Math.max(...curricula.flatMap(c => c.semesters.length))).fill(null).map(x => []),
-        totalCredits: 0
-    }
-    console.log(`Generated ${mergedCurriculum.semesters.length} blank semesters`)
-    // Create object reference/pointer to the semesters as a shorthand
-    const mergedSemesters: Vertex[][] = mergedCurriculum.semesters
-    
-    const courseListSets: Array<Set<string>> = []
+ * 
+ */
+export async function MergeCurricula(curricula: Curriculum[]): Promise<{ [code: string]: Vertex }> {
+    // Instead of having a 1D Array to hold the vertex data, we instead use an object literal, this should help 
+    // when building the initial list of courses and will be easier to work with during the build step
+    // as opposed to using a full curriculum object
+    const result: { [code: string]: Vertex } = {}
 
-    console.log('Loading course information')
-    // For each curriculum, create a Set of all classes course codes
-    for (const curriculum of curricula) {
-        const allCourses = curriculum.semesters.flat()
-        for (const course of allCourses) {
-            console.log(JSON.stringify(course))
-            mergedSemesters[course.semester - 1].push(course)
-        }
-        courseListSets.push(new Set(allCourses.map(course => course.courseCode)))
-    }
-    console.log('Course information loaded')
-
-    for (const a of courseListSets) { // DEBUG:
-        for (const b of a) {
-            console.log(`[Course Info] ${b}`)
-        }
-    }
-
-    console.log('Checking for duplicate courses')
-    // Determine what course codes are shared accross two or more curriculums
-    let duplicateCourseCodesSet: Set<string> = new Set()
-    for (let i = 0; i < courseListSets.length; i++) {
-        for (let j = 0; j < courseListSets.length; j++) {
-            if (i === j) continue
-            
-            const intersection = courseListSets[i].intersection(courseListSets[j])
-            
-            if (intersection.size > 0) duplicateCourseCodesSet = duplicateCourseCodesSet.union(intersection)
-        }
-    }
-    console.log(`Found ${duplicateCourseCodesSet.size} duplicate courses`)
-
-    // For each course that occurs more than once, calcuate its path in all curricula is appears in and determine what semester it needs to be placed in (for now)
-    for (const courseCode of duplicateCourseCodesSet) {
-        console.log(`Checking duplicate: ${courseCode}`)
-        const paths: Vertex[][] = []
-        let mergedVertex: Vertex | null = null
-        // Grab verticies and curricula for the course code
-        const familiarCurricula = curricula.filter(curriculum => curriculum.semesters.flat().map(vertex => vertex.courseCode).includes(courseCode))
-        for await (const currentCurriculum of familiarCurricula) {
-            // Calculate path for each vertex
-            const vertex: Vertex = currentCurriculum.semesters.flat().find(vertex => vertex.courseCode === courseCode)
-            const path = await calculateCoursePath(vertex, currentCurriculum)
-            if (!mergedVertex) {
-                mergedVertex = { ...vertex }
+    // Loop over each curriculum that was passed in
+    for (let i = 0; i < curricula.length; i++) {
+        const currentCurriculum = curricula[i]
+        const courses = currentCurriculum.semesters.flat() // 1D array of the coureses in the current curriculum
+        // Loop over each course
+        for (let courseIndex = 0; courseIndex < courses.length; courseIndex++) {
+            const currentCourse = courses[courseIndex]
+            // If the current course has not been accounted for yet, add it (using DeepCopy to avoid messy obj reference pointers)
+            if (!result[currentCourse.courseCode]) {
+                result[currentCourse.courseCode] = DeepCopy<Vertex>(currentCourse)
             } else {
-                mergedVertex.edges = [...mergedVertex.edges, ...vertex.edges].filter((edge, i, arr) => arr.findIndex(edge2 => edge === edge2) === i)
-                mergedVertex.semesterLock = [ ...(mergedVertex.semesterLock || []), ...(vertex.semesterLock || []) ].filter((v, i, a) => a.findIndex(v2 => v === v2) === i)
-            }
-            console.log(JSON.stringify(mergedVertex))
-            paths.push(path)
-        }
-        // Determine semester spacing for placing the merged vertex
-        /**
-         * Indetify the absolute min and max semesters the vertex could be in
-         * This defines a range we can check for "empty" semesters that do not contain any courses in any of the concerned paths
-         * For each empty semester we find, we need to validate it by seeing that there are no courses between it and the vertex in each path
-         * If there are no valid empty semesters, we need to merge forward to the farthest/max semester and push all post reqs in other paths forward by a dynamic number of semesters that needs to be kept at a min
-        */
-        const minSemesterIndex = mergedSemesters.findIndex(semester => semester.find(vertex => vertex.courseCode === courseCode))
-        const maxSemesterIndex = mergedSemesters.findLastIndex(semester => semester.find(vertex => vertex.courseCode === courseCode))
-        // Will be -1 while there is no valid semester to merge to, otherwise it is the index of the mergedSemesters array
-        let validMergeSemesterIndex = -1
-        // Find empty semesters and check if they are valid candidates
-        for (let currentSemesterIndex = minSemesterIndex; currentSemesterIndex <= maxSemesterIndex; currentSemesterIndex++) {
-            const currentSemester = currentSemesterIndex + 1
-            const duplicateVertices: Map<number, Vertex> = new Map
-            let isEmptySemester = true
-            for (let j = 0; j < paths.length; j++) {
-                const duplicateVertex = paths[j].find(vertex => vertex.courseCode === courseCode)
-                duplicateVertices.set(j, duplicateVertex)
-                if (duplicateVertex.semester === currentSemester) continue
-                const blockingVertex: Vertex | undefined = paths[j].find(vertex => vertex.courseCode !== courseCode && vertex.semester === currentSemester && vertex.semester !== duplicateVertex.semester)
-                // Semester is not a valid candidate for merging
-                if (blockingVertex !== undefined) {
-                    isEmptySemester = false
-                    break
-                }
-            }
-            if (isEmptySemester) {
-                let isValidSemester = true
-                // Validate that we can actually merge to it
-                // Rule for a valid merge:
-                // 1. Must be adjacent to or in the same semester as all duplicate vertices OR
-                // 2. Must not have any pre/post reqs (depending on direction) between the duplicate and the candidate semester
-                for (const [pathIndex, duplicateVertex] of duplicateVertices) {
-                    const semesterDistance = Math.abs(duplicateVertex.semester - currentSemester)
-                    // Semester is valid if the semesters are adjacent
-                    if (semesterDistance <= 1) continue
-                    const path = paths[pathIndex]
-                    const intermediaryCourses = path.filter(vertex => currentSemester > duplicateVertex.semester ? vertex.semester > duplicateVertex.semester && vertex.semester < currentSemester : vertex.semester < duplicateVertex.semester && vertex.semester > currentSemester)
-                    // If there are no courses blocking the duplicate from merging, then it is a valid semester
-                    if (intermediaryCourses.length === 0) continue
-                    // Default case: the current semester is not valid
-                    isValidSemester = false
-                    break
-                }
-                if (isValidSemester) {
-                    validMergeSemesterIndex = currentSemesterIndex
-                    break
-                }
+                // Current course was already added, merge any additional edges that were not present in the other occurance of the course
+                result[currentCourse.courseCode].edges.push(...currentCourse.edges)
+                result[currentCourse.courseCode].edges = result[currentCourse.courseCode].edges.filter((v, i, a) => a.indexOf(v) === i)
             }
         }
-
-        // If we could not merge the course, we need to merge it forward and push all post reqs back
-        if (validMergeSemesterIndex === -1) {
-            console.log(`No valid semester found to merge ${courseCode} to, merging forward to latest occurance of course`)
-            mergedVertex.semester = maxSemesterIndex + 1
-            // Grab the first layer of post-reqs from the merged vertex
-            const firstLayerPostReqs = mergedSemesters.flat().filter(v => mergedVertex.edges.find(edge => edge === v.courseCode))
-            for (const node of firstLayerPostReqs) {
-                const tempMergedSemesters = DeepCopy<Vertex[][]>(mergedSemesters)
-                const tempMergedVertex = tempMergedSemesters.flat().find(v => v.courseCode === mergedVertex.courseCode)
-                const tempNode = tempMergedSemesters.flat().find(v => v.courseCode === node.courseCode)
-                // Move the postreq forward the smallest amount we can
-                // NOTE: I don't think it matters if a post-req is itself is a duplicate
-                //const vertex = mergedSemesters.flat().find(vertex => vertex.courseCode === node.courseCode)
-                if (mergedVertex.semester > node.semester ) { // Layer 1 post-req has ended up behind the current course
-                    console.log(`Shifting branch for ${courseCode} staring at ${node.courseCode}`)
-                    // We need to shift the current "branch" starting from the current vertex
-                    await ShiftBranch(tempNode, tempMergedVertex, tempMergedSemesters)
-                    // Check for fail signal
-                    const shiftFailed = tempMergedSemesters.flat().find(course => course.semester < 1)
-                    if (!shiftFailed) {
-                        // Shift was valid
-                        mergedSemesters.length = 0
-                        mergedSemesters.push(...tempMergedSemesters)
-                    }
-                }
-            }
-        } else {
-            console.log(`Found a valid candidate semester to merge duplicate ${courseCode} to: ${validMergeSemesterIndex + 1}`)
-            // We found a semester we can merge to, however we still need look to see if any post-reqs need pushing back
-            mergedVertex.semester = validMergeSemesterIndex + 1
-            for (const edge of mergedVertex.edges) { // LATER: Look at seeing if we can optimize this step
-                const tempMergedSemesters = DeepCopy<Vertex[][]>(mergedSemesters)
-                const tempMergedVertex = tempMergedSemesters.flat().find(v => v.courseCode === mergedVertex.courseCode)
-                const currVertex = tempMergedSemesters.flat().find(v => v.courseCode === edge)
-                console.log(JSON.stringify(currVertex))
-                console.log(edge)
-                console.log(`Shifting branch for ${courseCode} starting at ${edge}`)
-                await ShiftBranch(currVertex, tempMergedVertex, tempMergedSemesters)
-                // Check for fail signal
-                const shiftFailed = tempMergedSemesters.flat().find(course => course.semester < 1)
-                if (!shiftFailed) {
-                    // Shift was valid
-                    mergedSemesters.length = 0
-                    mergedSemesters.push(...tempMergedSemesters)
-                }
-            }
-        }
-        console.log(`Removing excess instances of ${courseCode}`)
-        // Remove any occurance of the duplicate before inserting the merged instance
-        for (let i = 0; i < mergedSemesters.length; i++) {
-            const currSemester = mergedSemesters[i]
-            let duplicateIndex = currSemester.findIndex(vertex => vertex.courseCode === courseCode)
-            while (duplicateIndex !== -1) {
-                currSemester.splice(duplicateIndex, 1)
-                duplicateIndex = currSemester.findIndex(vertex => vertex.courseCode === courseCode)
-            }
-        }
-        // Replace/insert the merged vertex into the proper semester
-        mergedSemesters[mergedVertex.semester - 1].push({ ...mergedVertex })
-        console.log(`Completed checks for duplicate: ${courseCode}`)
     }
 
-    // NOTE: All of the moving around before this point has been purely on paper, the actual location of the courses has not changed (yet)
-    // Cleanup step: Ensure all courses are in the correct semesters after we've been shifting them around
-    console.log('Cleaning up merge step')
- 
-    await UpdateMovedCourses(mergedSemesters)
-
-    console.log('Merge step complete')
-    mergedCurriculum.semesters = mergedCurriculum.semesters.map(semester => semester.sort((a, b) => createHash('md5').update(a.courseCode).digest('hex').split('').reduce((a, c) => a + c.charCodeAt(0), 0) - createHash('md5').update(b.courseCode).digest('hex').split('').reduce((a, c) => a + c.charCodeAt(0), 0)))
-    mergedCurriculum.totalCredits = mergedCurriculum.semesters.reduce((acc, curr) => acc + curr.reduce((acc2, curr2) => acc2 + curr2.credits, 0), 0)
-    return mergedCurriculum
+    return result
 }
-
-async function MergeUnitTest(stacks: string[]): Promise<void> {
-    const fileContents = []
-    for (const stack of stacks) {
-        const C1 = await readFile(`../../json/${stack}.json`, 'utf-8').catch(err => { if (err) throw err })        
-        fileContents.push(JSON.parse(C1 as string).data)
-    }
-    await MergeCurricula(fileContents).then(r => {
-        const output = process.argv.find(x => x.startsWith('--o:'))
-        if (output) {
-            writeFile(`../../testing/${output.split(':')[1]}.json`, JSON.stringify(r), { encoding: 'utf-8' })
-        } else {
-            console.log(output)
-        }
-    })
-    console.log('Merge test complete')
-}
-
-const mergeTest = process.argv.find(x => x.startsWith('--test:merge:'))
-if (mergeTest) MergeUnitTest(mergeTest.split(':')[2].split(','))


### PR DESCRIPTION
Overhaul of merge to no longer use full curriculum objects. This was done in part to play nicely with the new build step.

Multiple other changes to utils and other steps to match up with the changes done to merge.